### PR TITLE
Add the new deprecated wagtail module routes

### DIFF
--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -18,7 +18,11 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+from wagtail.utils.version import get_main_version as get_wagtail_version
+if get_wagtail_version() >= "4.0.0":
+    from wagtail import urls as wagtail_urls
+else:
+    from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [

--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -19,10 +19,12 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.utils.version import get_main_version as get_wagtail_version
+
 if get_wagtail_version() >= "4.0.0":
     from wagtail import urls as wagtail_urls
 else:
     from wagtail.core import urls as wagtail_urls
+
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [

--- a/salesman/admin/wagtail/mixins.py
+++ b/salesman/admin/wagtail/mixins.py
@@ -6,8 +6,8 @@ from django.urls import re_path, reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-
 from wagtail.utils.version import get_main_version as get_wagtail_version
+
 if get_wagtail_version() >= "3.0.0":
     from wagtail.admin.panels import (
         FieldPanel,

--- a/salesman/admin/wagtail/mixins.py
+++ b/salesman/admin/wagtail/mixins.py
@@ -8,7 +8,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.utils.version import get_main_version as get_wagtail_version
-if get_wagtail_version() >= "4.0.0":
+if get_wagtail_version() >= "3.0.0":
     from wagtail.admin.panels import (
         FieldPanel,
         InlinePanel,

--- a/salesman/admin/wagtail/mixins.py
+++ b/salesman/admin/wagtail/mixins.py
@@ -6,13 +6,24 @@ from django.urls import re_path, reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.edit_handlers import (
-    FieldPanel,
-    InlinePanel,
-    MultiFieldPanel,
-    ObjectList,
-    TabbedInterface,
-)
+
+from wagtail.utils.version import get_main_version as get_wagtail_version
+if get_wagtail_version() >= "4.0.0":
+    from wagtail.admin.panels import (
+        FieldPanel,
+        InlinePanel,
+        MultiFieldPanel,
+        ObjectList,
+        TabbedInterface,
+    )
+else:
+    from wagtail.admin.edit_handlers import (
+        FieldPanel,
+        InlinePanel,
+        MultiFieldPanel,
+        ObjectList,
+        TabbedInterface,
+    )
 
 from salesman.orders.models import BaseOrder
 

--- a/salesman/admin/wagtail/panels.py
+++ b/salesman/admin/wagtail/panels.py
@@ -8,15 +8,15 @@ from django.utils.formats import date_format
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from wagtail.utils.version import get_main_version as get_wagtail_version
 
 from salesman.conf import app_settings
 
 from ..utils import format_price
 
-from wagtail.utils.version import get_main_version as get_wagtail_version    
-
 if get_wagtail_version() < "3.0.0":  # pragma: no cover
     from wagtail.admin.edit_handlers import EditHandler as Panel
+
     # Attach dummy BoundPanel class for older Wagtail versions
     Panel.BoundPanel = object
 else:

--- a/salesman/admin/wagtail/panels.py
+++ b/salesman/admin/wagtail/panels.py
@@ -8,12 +8,16 @@ from django.utils.formats import date_format
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.edit_handlers import EditHandler as Panel
-from wagtail.utils.version import get_main_version as get_wagtail_version
 
 from salesman.conf import app_settings
 
 from ..utils import format_price
+
+from wagtail.utils.version import get_main_version as get_wagtail_version
+if get_wagtail_version() >= "4.0.0":
+    from wagtail.admin.panels import Panel
+else: 
+    from wagtail.admin.edit_handlers import EditHandler as Panel
 
 if get_wagtail_version() < "3.0.0":  # pragma: no cover
     # Attach dummy BoundPanel class for older Wagtail versions

--- a/salesman/admin/wagtail/panels.py
+++ b/salesman/admin/wagtail/panels.py
@@ -13,15 +13,14 @@ from salesman.conf import app_settings
 
 from ..utils import format_price
 
-from wagtail.utils.version import get_main_version as get_wagtail_version
-if get_wagtail_version() >= "4.0.0":
-    from wagtail.admin.panels import Panel
-else: 
-    from wagtail.admin.edit_handlers import EditHandler as Panel
+from wagtail.utils.version import get_main_version as get_wagtail_version    
 
 if get_wagtail_version() < "3.0.0":  # pragma: no cover
+    from wagtail.admin.edit_handlers import EditHandler as Panel
     # Attach dummy BoundPanel class for older Wagtail versions
     Panel.BoundPanel = object
+else:
+    from wagtail.admin.panels import Panel
 
 
 class ReadOnlyPanel(Panel):

--- a/salesman/admin/wagtail_hooks.py
+++ b/salesman/admin/wagtail_hooks.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Type
 
-from wagtail.admin.edit_handlers import EditHandler, ObjectList
+from wagtail.utils.version import get_main_version as get_wagtail_version
+if get_wagtail_version() >= "4.0.0":
+    from wagtail.admin.panels import EditHandler, ObjectList
+else:
+    from wagtail.admin.edit_handlers import EditHandler, TabbedInterface as ObjectList
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from salesman.conf import app_settings

--- a/salesman/admin/wagtail_hooks.py
+++ b/salesman/admin/wagtail_hooks.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from typing import Any, Type
 
 from wagtail.utils.version import get_main_version as get_wagtail_version
+
 if get_wagtail_version() >= "3.0.0":
     from wagtail.admin.panels import EditHandler, ObjectList
 else:
     from wagtail.admin.edit_handlers import EditHandler, TabbedInterface as ObjectList
+
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from salesman.conf import app_settings

--- a/salesman/admin/wagtail_hooks.py
+++ b/salesman/admin/wagtail_hooks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Type
 
 from wagtail.utils.version import get_main_version as get_wagtail_version
-if get_wagtail_version() >= "4.0.0":
+if get_wagtail_version() >= "3.0.0":
     from wagtail.admin.panels import EditHandler, ObjectList
 else:
     from wagtail.admin.edit_handlers import EditHandler, TabbedInterface as ObjectList


### PR DESCRIPTION
This is an updated version of #28 with fixed linting issues

Thank you for contributing to Salesman, before you continue make sure that:
- Tests still pass: `poetry run pytest`
- There are no lint errors: `poetry run pre-commit run --all-files`
