### PR TITLE
Add order model example to docs

### DIFF
--- a/docs/checkout_and_payment.rst
+++ b/docs/checkout_and_payment.rst
@@ -13,7 +13,15 @@ which accepts a list of dotted paths to :class:`salesman.checkout.payment.Paymen
 
 .. raw:: html
 
-    <h3>1. Create payment method</h3>
+    <h3>1. Create order model</h3>
+
+In this example we don't modify the Order model, but you can if you want to.
+
+.. literalinclude:: /../example/shop/models/order.py
+
+.. raw:: html
+
+    <h3>2. Create payment method</h3>
 
 First create your custom payment method. Payment methods are required to specify a ``label`` and
 a unique ``identifier`` property on class. To enable payment for the basket you should also
@@ -23,7 +31,7 @@ override the :meth:`salesman.checkout.payment.PaymentMethod.basket_payment` meth
 
 .. raw:: html
 
-    <h3>2. Register payment method</h3>
+    <h3>3. Register payment method</h3>
 
 Then register your payment method in ``settings.py``:
 

--- a/docs/checkout_and_payment.rst
+++ b/docs/checkout_and_payment.rst
@@ -13,9 +13,9 @@ which accepts a list of dotted paths to :class:`salesman.checkout.payment.Paymen
 
 .. raw:: html
 
-    <h3>1. Create order model</h3>
+    <h3>1. Create swappable order model</h3>
 
-In this example we don't modify the Order model, but you can if you want to.
+It is recommended to configure and setup all Salesman models as swappable even if it's not necessary at the beginning. This will future-proof your application in case you wish to add it later. This has to be done before the initial migrations are created. See :ref:`swappable_models`.
 
 .. literalinclude:: /../example/shop/models/order.py
 


### PR DESCRIPTION
Currently the "Checkout and Payment" documentation page has an example payment.py that does not work if you follow the guide, because the guide never has you set up the custom Order model that it's using behind the scenes.

Thank you for contributing to Salesman, before you continue make sure that:
- Tests still pass: `poetry run pytest`
- There are no lint errors: `poetry run pre-commit run --all-files`
