### PR TITLE
Add support for Wagtail-6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,14 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["4.1", "4.2"]
-        wagtail-version: ["4.0", "5.0"]
+        wagtail-version: ["4.0", "5.0", "6.0"]
         exclude:
           - django-version: "4.2"
             wagtail-version: "4.0"
+          - django-version: "4.0"
+            wagtail-version: "6.0"
+          - django-version: "4.1"
+            wagtail-version: "6.0"
         include:
           - python-version: "3.11"
             django-version: "4.2"

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -58,7 +58,7 @@ INSTALLED_APPS = [
     # wagtail
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
-    "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtail.embeds",
     "wagtail.sites",
     "wagtail.users",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Topic :: Internet",
@@ -33,7 +34,8 @@ djangorestframework = ">=3.11.1,<4.0"
 
 # Optional
 Pygments = {version = "^2.6", optional = true}
-wagtail = {version = ">=4.0,<6.0", optional = true}
+wagtail = {version = ">=4.0,<7.0", optional = true}
+wagtail_modeladmin = {version = ">=2.0", optional = true}
 pytest = {version = "~7.3.1", optional = true}
 pytest-django = {version = "~4.5.2", optional = true}
 pytest-cov = {version = "~4.0.0", optional = true}
@@ -51,14 +53,14 @@ mypy = "~1.2.0"
 
 [tool.poetry.extras]
 pygments = ["Pygments"]
-example = ["Pygments", "wagtail"]
-tests = ["Pygments", "wagtail", "pytest", "pytest-django", "pytest-cov"]
-docs = ["wagtail", "sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "sphinxcontrib-httpdomain"]
+example = ["Pygments", "wagtail", "wagtail_modeladmin"]
+tests = ["Pygments", "wagtail", "wagtail_modeladmin", "pytest", "pytest-django", "pytest-cov"]
+docs = ["wagtail", "wagtail_modeladmin", "sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "sphinxcontrib-httpdomain"]
 
 [tool.isort]
 profile = "black"
 known_first_party = ["salesman", "shop"]
-known_third_party = ["rest_framework", "wagtail", "pytest"]
+known_third_party = ["rest_framework", "wagtail", "wagtail_modeladmin", "pytest"]
 
 [tool.mypy]
 exclude = ["example"]

--- a/salesman/admin/wagtail/helpers.py
+++ b/salesman/admin/wagtail/helpers.py
@@ -2,11 +2,19 @@ from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.utils.translation import gettext_lazy as _
-from wagtail.contrib.modeladmin.helpers import (
-    AdminURLHelper,
-    ButtonHelper,
-    PermissionHelper,
-)
+
+try:
+    from wagtail.contrib.modeladmin.helpers import (
+        AdminURLHelper,
+        ButtonHelper,
+        PermissionHelper,
+    )
+except ImportError:
+    from wagtail_modeladmin.helpers import (
+        AdminURLHelper,
+        ButtonHelper,
+        PermissionHelper,
+    )
 
 
 class OrderPermissionHelper(PermissionHelper):

--- a/salesman/admin/wagtail/views.py
+++ b/salesman/admin/wagtail/views.py
@@ -9,7 +9,11 @@ from django.urls import NoReverseMatch
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin import messages
-from wagtail.contrib.modeladmin.views import DeleteView, EditView, IndexView
+
+try:
+    from wagtail.contrib.modeladmin.views import DeleteView, EditView, IndexView
+except ImportError:
+    from wagtail_modeladmin.views import DeleteView, EditView, IndexView
 
 
 class OrderIndexView(IndexView):

--- a/salesman/admin/wagtail_hooks.py
+++ b/salesman/admin/wagtail_hooks.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import Type
 
 from wagtail.admin.panels import ObjectList, Panel
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+
+try:
+    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+except ImportError:
+    from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 
 from salesman.conf import app_settings
 from salesman.core.utils import get_salesman_model

--- a/salesman/orders/models.py
+++ b/salesman/orders/models.py
@@ -290,7 +290,12 @@ class BaseOrder(ClusterableModel):
         if (
             "salesman.admin" in settings.INSTALLED_APPS
             and "wagtail.admin" in settings.INSTALLED_APPS
-            and "wagtail.contrib.modeladmin" in settings.INSTALLED_APPS
+            and any(
+                [
+                    "wagtail.contrib.modeladmin" in settings.INSTALLED_APPS,
+                    "wagtail_modeladmin" in settings.INSTALLED_APPS,
+                ]
+            )
         ):
             from salesman.admin.wagtail.mixins import WagtailOrderAdminMixin
 


### PR DESCRIPTION
This PR adds support for Wagtail >6.0, which removed `wagtail.contrib.modeladmin`, and recommends to use `wagtail_modeladmin` instead.

- Tests still pass: `poetry run pytest`: :heavy_check_mark:
- There are no lint errors: `poetry run pre-commit run --all-files`: :heavy_check_mark: 
